### PR TITLE
meson.build: fix libgcrypt detection on system without libgcrypt-config

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1064,7 +1064,6 @@ endif
 if not gnutls_crypto.found()
   if (not get_option('gcrypt').auto() or have_system) and not get_option('nettle').enabled()
     gcrypt = dependency('libgcrypt', version: '>=1.8',
-                        method: 'config-tool',
                         required: get_option('gcrypt'),
                         kwargs: static_kwargs)
     # Debian has removed -lgpg-error from libgcrypt-config


### PR DESCRIPTION
libgcrypt starts providing correct pkg-config configuration since 1.9, in parallel with libgcrypt-config. Since 1.11 it may also stop installing libgcrypt-config in some scenarios. Use the auto method for detection of libgcrypt, in which meson will try both pkg-config and libgcrypt-config.

Auto method for libgcrypt is supported by meson since 0.49.0, which is higher than the version qemu requires.



(cherry picked from commit 581b4cd5f16d618787bd1e292b851c62c2626da0)